### PR TITLE
Add auto-dismiss and sound support for Linux notifications

### DIFF
--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ For Linux systems using `notify-send`, notifications will automatically dismiss 
 
 ;; Keep notifications in system tray
 (setq claudemacs-notification-auto-dismiss-linux nil)
+
+;; Play sound with notifications (requires canberra-gtk-play)
+;; Common sound IDs: "message-new-instant", "bell", "dialog-error", "dialog-warning"
+(setq claudemacs-notification-sound-linux "message-new-instant")
+
+;; Disable sound
+(setq claudemacs-notification-sound-linux "")
 ```
 
 #### -- Windows --
@@ -307,6 +314,10 @@ Claudemacs provides several customization variables to tailor the experience to 
 
 ;; Auto-dismiss Linux notifications instead of persisting to system tray (default: t)
 (setq claudemacs-notification-auto-dismiss-linux nil)
+
+;; Sound for Linux notifications using canberra-gtk-play (default: "bell")
+;; Common sound IDs: "message-new-instant", "bell", "dialog-error", "dialog-warning"
+(setq claudemacs-notification-sound-linux "message-new-instant")
 ```
 
 All variables can also be customized via `M-x customize-group RET claudemacs RET`.

--- a/README.md
+++ b/README.md
@@ -139,9 +139,21 @@ Now you should receive System notifications when Claude Code is waiting for inpu
 
 Also, clicking on the notification doesn't bring you to Emacs. Open to ideas on how to fix that.
 
-#### -- Linux / Windows --
+#### -- Linux --
 
-I have not tested on linux or windows, so would appreciate any help there (PRs welcome).
+For Linux systems using `notify-send`, notifications will automatically dismiss by default instead of persisting in the system tray. You can control this behavior with:
+
+```elisp
+;; Auto-dismiss notifications (default: t)
+(setq claudemacs-notification-auto-dismiss-linux t)
+
+;; Keep notifications in system tray
+(setq claudemacs-notification-auto-dismiss-linux nil)
+```
+
+#### -- Windows --
+
+I have not tested on windows, so would appreciate any help there (PRs welcome).
 
 ### Fonts
 
@@ -292,6 +304,9 @@ Claudemacs provides several customization variables to tailor the experience to 
 ;; Available sounds: Basso, Blow, Bottle, Frog, Funk, Glass, Hero, Morse, 
 ;; Ping, Pop, Purr, Sosumi, Submarine, Tink
 (setq claudemacs-notification-sound-mac "Ping")
+
+;; Auto-dismiss Linux notifications instead of persisting to system tray (default: t)
+(setq claudemacs-notification-auto-dismiss-linux nil)
 ```
 
 All variables can also be customized via `M-x customize-group RET claudemacs RET`.

--- a/claudemacs.el
+++ b/claudemacs.el
@@ -121,6 +121,14 @@ This setting only affects Linux systems using notify-send."
   :type 'boolean
   :group 'claudemacs)
 
+(defcustom claudemacs-notification-sound-linux "bell"
+  "The sound to use when displaying system notifications on Linux.
+Uses canberra-gtk-play if available.  Common sound IDs include:
+`message-new-instant', `bell', `dialog-error', `dialog-warning'.
+When empty string, no sound is played."
+  :type 'string
+  :group 'claudemacs)
+
 (defface claudemacs-repl-face
   nil
   "Face for Claude REPL."
@@ -248,13 +256,17 @@ This works across macOS, Linux, and Windows platforms."
       (call-process "osascript" nil nil nil
                     "-e" (format "display notification \"%s\" with title \"%s\" sound name \"%s\""
                                 message title claudemacs-notification-sound-mac)))
-     ;; Linux with notify-send
+     ;; Linux with notify-send and canberra-gtk-play
      ((and (eq system-type 'gnu/linux)
            (executable-find "notify-send"))
       (let ((args (if claudemacs-notification-auto-dismiss-linux
                       (list "--hint=int:transient:1" title message)
                     (list title message))))
-        (apply #'call-process "notify-send" nil nil nil args)))
+        (apply #'call-process "notify-send" nil nil nil args))
+      (when (and (not (string-empty-p claudemacs-notification-sound-linux))
+                 (executable-find "canberra-gtk-play"))
+        (call-process "canberra-gtk-play" nil nil nil
+                      "--id" claudemacs-notification-sound-linux)))
      ;; Linux with kdialog (KDE)
      ((and (eq system-type 'gnu/linux)
            (executable-find "kdialog"))

--- a/claudemacs.el
+++ b/claudemacs.el
@@ -113,6 +113,14 @@ System sounds include: `Basso', `Blow', `Bottle', `Frog', `Funk',
   :type 'string
   :group 'claudemacs)
 
+(defcustom claudemacs-notification-auto-dismiss-linux t
+  "Whether to auto-dismiss notifications on Linux (don't persist to system tray).
+When non-nil, notifications will automatically disappear and not stay in the tray.
+When nil, notifications will persist in the system tray according to system defaults.
+This setting only affects Linux systems using notify-send."
+  :type 'boolean
+  :group 'claudemacs)
+
 (defface claudemacs-repl-face
   nil
   "Face for Claude REPL."
@@ -243,7 +251,10 @@ This works across macOS, Linux, and Windows platforms."
      ;; Linux with notify-send
      ((and (eq system-type 'gnu/linux)
            (executable-find "notify-send"))
-      (call-process "notify-send" nil nil nil title message))
+      (let ((args (if claudemacs-notification-auto-dismiss-linux
+                      (list "--hint=int:transient:1" title message)
+                    (list title message))))
+        (apply #'call-process "notify-send" nil nil nil args)))
      ;; Linux with kdialog (KDE)
      ((and (eq system-type 'gnu/linux)
            (executable-find "kdialog"))


### PR DESCRIPTION
This enhances Linux notifications with two new features: automatic dismissal and audio feedback.

Notifications now use the transient hint for `notify-send`, causing them to auto-dismiss instead of persisting in the system tray. This behavior is configurable via `claudemacs-notification-auto-dismiss-linux` and is enabled by default.

Sound support is implemented using `canberra-gtk-play` with common system sound IDs. Users can configure sounds through `claudemacs-notification-sound-linux` or disable by setting an empty string.