### PR TITLE
update built-in use-package usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,14 @@ Then in your `config.el`:
 (use-package! claudemacs)
 ```
 
-#### use-package with :vc (Emacs 29+)
+#### use-package with built-in :vc (Emacs 30+)
+
+```elisp
+(use-package claudemacs
+  :vc (:url "https://github.com/cpoile/claudemacs"))
+```
+
+#### use-package with vc-use-package
 
 ```elisp
 (use-package claudemacs


### PR DESCRIPTION
I'm using Emacs 30 and had issues installing claudemacs when using the `:fetcher` keyword. The vc-use-package mentions that the [built-in core version uses different syntax](https://github.com/slotThe/vc-use-package/blob/master/README.md) (see note at the top).  


Using the `use-package` call from the README.md resulted in the following error for me: 

```
⛔ Error (use-package): Failed to parse package claudemacs: use-package: Keyword :vc received unknown argument: (:fetcher github :repo cpoile/claudemacs). Supported keywords are: (:url :branch :lisp-dir :main-file :vc-backend :rev :shell-command :make :ignored-files)
```

In the end the following worked for me (without installing anything that doesn't ship with Emacs 30):

```elisp
(use-package claudemacs
  :vc (:url "https://github.com/cpoile/claudemacs"))
```
